### PR TITLE
[13] Heading components

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,9 +3,20 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <div class="govuk-grid-row">
-          Some text
+          <%= render 'layouts/components/headings/one', text: 'Example heading one' %>
         </div>
-        <%= render 'layouts/components/full_bleed_image', alt_text: 'example image', image_src: asset_url('full-width-example.png') %>
+        <div class="govuk-grid-row">
+          <%= render 'layouts/components/headings/two', text: 'Example heading two' %>
+        </div>
+        <div class="govuk-grid-row">
+          <%= render 'layouts/components/headings/three', text: 'Example heading three' %>
+        </div>
+        <div class="govuk-grid-row">
+          <%= render 'layouts/components/headings/four', text: 'Example heading four' %>
+        </div>
+        <div class="govuk-grid-row">
+          <%= render 'layouts/components/full_bleed_image', alt_text: 'example image', image_src: asset_url('full-width-example.png') %>
+        </div>
         <div class="govuk-grid-row">
           Some other text
         </div>

--- a/app/views/layouts/components/_full_bleed_image.html.erb
+++ b/app/views/layouts/components/_full_bleed_image.html.erb
@@ -1,3 +1,1 @@
-<div class="govuk-grid-row">
   <img class="dfe-image__full-bleed" alt="<%= alt_text %>" src="<%= image_src %>"/>
-</div>

--- a/app/views/layouts/components/headings/_four.html.erb
+++ b/app/views/layouts/components/headings/_four.html.erb
@@ -1,0 +1,1 @@
+<h4 class="govuk-heading-s"><%= text %></h4>

--- a/app/views/layouts/components/headings/_one.html.erb
+++ b/app/views/layouts/components/headings/_one.html.erb
@@ -1,0 +1,1 @@
+<h1 class="govuk-heading-xl"><%= text %></h1>

--- a/app/views/layouts/components/headings/_three.html.erb
+++ b/app/views/layouts/components/headings/_three.html.erb
@@ -1,0 +1,1 @@
+<h3 class="govuk-heading-m"><%= text %></h3>

--- a/app/views/layouts/components/headings/_two.html.erb
+++ b/app/views/layouts/components/headings/_two.html.erb
@@ -1,0 +1,2 @@
+<h2 class="govuk-heading-l"><%= text %></h2>
+


### PR DESCRIPTION
Adds heading components for H1 -> H4

Currently these just use the GOV.UK design system headings and act as a wrapper around them

![image](https://user-images.githubusercontent.com/976254/59266245-197d9680-8c3f-11e9-9b6d-985328be0bde.png)
