### PR TITLE
Remove extra main to be defined on each page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,9 +37,7 @@
     document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>
 <div class="govuk-width-container">
-  <main class="govuk-main-wrapper " id="main-content" role="main">
-    <%= yield %>
-  </main>
+  <%= yield %>
 </div>
 <%= render 'layouts/footer' %>
 </body>


### PR DESCRIPTION
For accessibility purposes we should only have the skip link around the actual content (hero images should be able to be skipped)