### PR TITLE
Fix incorrect CSS class used in resources section

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -116,7 +116,7 @@
               <p class="govuk-body govuk-!-margin-top-5">Practical advice and tools for school leaders and teachers to help review and reduce workload</p>
             </div>
           </div>
-          <div class="govuk-grid-row govuk-!-padding-top-9 align-resource_link_with_icons-center">
+          <div class="govuk-grid-row govuk-!-padding-top-9 align-items-center">
             <div class="govuk-grid-column-one-half">
               <%= render 'layouts/components/images/default', image_src: asset_url('teacher.png') %>
             </div>


### PR DESCRIPTION
Changes the CSS class used for 'Safeguarding & mental health in schools' part in the Resources section so that it's correctly vertically aligned in the middle.