### PR TITLE
Add check for alignment defined in heading partials

### DIFF
--- a/app/views/layouts/components/headings/_four.html.erb
+++ b/app/views/layouts/components/headings/_four.html.erb
@@ -1,1 +1,1 @@
-<h4 class="govuk-heading-s text-align-<%= alignment.downcase %>"><%= text %></h4>
+<h4 class="govuk-heading-s text-align-<%= alignment.downcase if defined?(alignment) %>"><%= text %></h4>

--- a/app/views/layouts/components/headings/_four.html.erb
+++ b/app/views/layouts/components/headings/_four.html.erb
@@ -1,1 +1,1 @@
-<h4 class="govuk-heading-s text-align-<%= alignment.downcase if defined?(alignment) %>"><%= text %></h4>
+<h4 class="govuk-heading-s <%= "text-align-#{alignment.downcase}" if defined?(alignment) %>"><%= text %></h4>

--- a/app/views/layouts/components/headings/_one.html.erb
+++ b/app/views/layouts/components/headings/_one.html.erb
@@ -1,1 +1,1 @@
-<h1 class="govuk-heading-xl text-align-<%= alignment.downcase if defined?(alignment) %>"><%= text %></h1>
+<h1 class="govuk-heading-xl <%= "text-align-#{alignment.downcase}" if defined?(alignment) %>"><%= text %></h1>

--- a/app/views/layouts/components/headings/_one.html.erb
+++ b/app/views/layouts/components/headings/_one.html.erb
@@ -1,1 +1,1 @@
-<h1 class="govuk-heading-xl text-align-<%= alignment.downcase %>"><%= text %></h1>
+<h1 class="govuk-heading-xl text-align-<%= alignment.downcase if defined?(alignment) %>"><%= text %></h1>

--- a/app/views/layouts/components/headings/_three.html.erb
+++ b/app/views/layouts/components/headings/_three.html.erb
@@ -1,1 +1,1 @@
-<h3 class="govuk-heading-m text-align-<%= alignment.downcase %>"><%= text %></h3>
+<h3 class="govuk-heading-m text-align-<%= alignment.downcase if defined?(alignment) %>"><%= text %></h3>

--- a/app/views/layouts/components/headings/_three.html.erb
+++ b/app/views/layouts/components/headings/_three.html.erb
@@ -1,1 +1,1 @@
-<h3 class="govuk-heading-m text-align-<%= alignment.downcase if defined?(alignment) %>"><%= text %></h3>
+<h3 class="govuk-heading-m <%= "text-align-#{alignment.downcase}" if defined?(alignment) %>"><%= text %></h3>

--- a/app/views/layouts/components/headings/_two.html.erb
+++ b/app/views/layouts/components/headings/_two.html.erb
@@ -1,1 +1,1 @@
-<h2 class="govuk-heading-l text-align-<%= alignment.downcase %>"><%= text %></h2>
+<h2 class="govuk-heading-l text-align-<%= alignment.downcase if defined?(alignment) %>"><%= text %></h2>

--- a/app/views/layouts/components/headings/_two.html.erb
+++ b/app/views/layouts/components/headings/_two.html.erb
@@ -1,1 +1,1 @@
-<h2 class="govuk-heading-l text-align-<%= alignment.downcase if defined?(alignment) %>"><%= text %></h2>
+<h2 class="govuk-heading-l <%= "text-align-#{alignment.downcase}" if defined?(alignment) %>"><%= text %></h2>


### PR DESCRIPTION
This is a quick fix to allow `alignment` to not be passed into a `headings` partial. This will be rectified in a future PR where we will move the rendering of components into a single partial.