### PR TITLE
Remove heading field from multiple columns

### DIFF
--- a/lib/gateway/contentful_gateway.rb
+++ b/lib/gateway/contentful_gateway.rb
@@ -160,7 +160,6 @@ private
     {
       type: :columns,
       data: {
-        heading: content.heading.text,
         columns: columns_array
       }
     }


### PR DESCRIPTION
This is being removed because the `heading` field in the `columns` content type is not actually used and displayed in the frontend. See below.

https://github.com/DFE-Digital/single-place-for-education-frontend/blob/5d3e7dd9f24047708e8db6ecf50f38c4c6405de8/app/views/layouts/renderers/_component_renderer.html.erb#L23-L30

It also breaks the frontend as it is not a required field in Contentful as there is no empty handling. See below on line 163.

https://github.com/DFE-Digital/single-place-for-education-frontend/blob/5d3e7dd9f24047708e8db6ecf50f38c4c6405de8/lib/gateway/contentful_gateway.rb#L155-L167

Currently, a heading has to be added (even though it is not required and displayed) to not break the frontend.

![image](https://user-images.githubusercontent.com/42817036/60023218-47c29380-968d-11e9-8fa2-e000ca17abb8.png)

Additionally, there is a duplication in functionality as a heading can be adding by just using a Heading content type in Contentful.