### PR TITLE
edit set default image height back to 50vh

### DIFF
--- a/app/assets/stylesheets/image.scss
+++ b/app/assets/stylesheets/image.scss
@@ -22,7 +22,7 @@
 
 .dfe-image__default {
   width: 100%;
-  height: 30vh;
+  max-height: 50vh;
   object-fit: cover;
 }
 


### PR DESCRIPTION
Setting the default image max-height back to 50vh to fix images on the homepage