### PR TITLE
Fix default link type for image link with description component

### DIFF
--- a/app/views/layouts/components/_image_link_with_description.html.erb
+++ b/app/views/layouts/components/_image_link_with_description.html.erb
@@ -1,7 +1,7 @@
-<% if defined?(link_type) && link_type == :internal %>
-  <a href="<%= defined?(link) ? link : '#' %>">
-<% else %>
+<% if defined?(link_type) && link_type == :external %>
   <a target="_blank" rel="nofollow noopener" href="<%= defined?(link) ? link : '#' %>">
+<% else %>
+  <a href="<%= defined?(link) ? link : '#' %>">
 <% end %>
   <img class="dfe-image__default govuk-!-margin-top-5 govuk-!-margin-bottom-5" alt="image" src="<%= image_src %>"/>
 </a>


### PR DESCRIPTION
When link type is not provided it defaults to an external link. This change makes it so the default is an internal link.