### PR TITLE
Update styling of visited links

### DIFF
--- a/app/assets/stylesheets/link.scss
+++ b/app/assets/stylesheets/link.scss
@@ -3,6 +3,10 @@
   text-decoration: none;
 }
 
+.govuk-breadcrumbs__link:visited, .govuk-link:visited {
+  color: #4c2c92;
+}
+
 .govuk-breadcrumbs__list-item {
   font-weight: 300;
   padding-left: 35px;


### PR DESCRIPTION
For visited links on the breadcrumb, these become black. This changes it to the default purple colour instead.

![image](https://user-images.githubusercontent.com/42817036/60581235-5b04eb80-9d7e-11e9-91eb-803e6ca3e3fd.png)

![image](https://user-images.githubusercontent.com/42817036/60581262-635d2680-9d7e-11e9-8979-2a4fb73d357b.png)
