### PR TITLE
Reduce large numbers list item spacing in mobile

### DIFF
--- a/app/assets/stylesheets/lists.scss
+++ b/app/assets/stylesheets/lists.scss
@@ -18,9 +18,13 @@
 
 .dfe-list__large-numbers-item {
   min-height: 70px;
-  margin: 0 0 3.5rem 0 !important;
+  margin: 0 0 2.5rem 0 !important;
   counter-increment: counter;
   display: flex;
+
+  @media (min-width: map-get($govuk-breakpoints, tablet)) {
+    margin: 0 0 3.5rem 0 !important;
+  }
 }
 
 .dfe-list__large-numbers-item::before {


### PR DESCRIPTION
This PR allows there to be a bit more content on a page for when a large numbers list is used on mobile by reducing the bottom margin size.

## Before

![image](https://user-images.githubusercontent.com/42817036/61444737-e4eab200-a943-11e9-9385-3873ac4bc551.png)

## After

![image](https://user-images.githubusercontent.com/42817036/61444678-c2f12f80-a943-11e9-8747-204478c3b4e7.png)
